### PR TITLE
fix(portfolio): fix crash-loop issue

### DIFF
--- a/apps/portfolio/src/pages/de/index.tsx
+++ b/apps/portfolio/src/pages/de/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import Head from 'next/head';
 import { deContent } from '@/config';
 import { Layout } from '@/components/layout';
@@ -16,6 +17,13 @@ import {
 export default function DeHomePage() {
   const content = deContent;
 
+  useEffect(() => {
+    document.documentElement.lang = 'de';
+    return () => {
+      document.documentElement.lang = 'en';
+    };
+  }, []);
+
   return (
     <>
       <Head>
@@ -27,7 +35,6 @@ export default function DeHomePage() {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={content.meta.title} />
         <meta name="twitter:description" content={content.meta.description} />
-        <html lang="de" />
       </Head>
 
       <Layout content={content}>

--- a/apps/portfolio/src/pages/nl/index.tsx
+++ b/apps/portfolio/src/pages/nl/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import Head from 'next/head';
 import { nlContent } from '@/config';
 import { Layout } from '@/components/layout';
@@ -16,6 +17,13 @@ import {
 export default function NlHomePage() {
   const content = nlContent;
 
+  useEffect(() => {
+    document.documentElement.lang = 'nl';
+    return () => {
+      document.documentElement.lang = 'en';
+    };
+  }, []);
+
   return (
     <>
       <Head>
@@ -27,7 +35,6 @@ export default function NlHomePage() {
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:title" content={content.meta.title} />
         <meta name="twitter:description" content={content.meta.description} />
-        <html lang="nl" />
       </Head>
 
       <Layout content={content}>


### PR DESCRIPTION
This pull request updates the way the language attribute is set for the German and Dutch portfolio pages. Instead of statically setting the `lang` attribute in the HTML via the `<html lang="..."/>` tag in the `Head` component, it now uses a `useEffect` hook to dynamically set `document.documentElement.lang` when the page is mounted, and resets it to `'en'` when the component is unmounted.

**Internationalization improvements:**

* Added a `useEffect` hook to both `de/index.tsx` and `nl/index.tsx` to set `document.documentElement.lang` to `'de'` or `'nl'` on mount, and revert it to `'en'` on unmount, ensuring the correct language attribute is set for each localized page. [[1]](diffhunk://#diff-228d07835fef06abd852bc0e070199fbde388e946cdae91b21b3cfd089d82c18R20-R26) [[2]](diffhunk://#diff-77e918c6d7d639c139f2553ac0770fae447958652ed1ae2b54b8a2ab6bcacc85R20-R26)
* Removed the static `<html lang="..."/>` tag from the `Head` component in both pages, as language is now set dynamically. [[1]](diffhunk://#diff-228d07835fef06abd852bc0e070199fbde388e946cdae91b21b3cfd089d82c18L30) [[2]](diffhunk://#diff-77e918c6d7d639c139f2553ac0770fae447958652ed1ae2b54b8a2ab6bcacc85L30)
* Added missing import of `useEffect` in both `de/index.tsx` and `nl/index.tsx` to support the new dynamic language setting. [[1]](diffhunk://#diff-228d07835fef06abd852bc0e070199fbde388e946cdae91b21b3cfd089d82c18R1) [[2]](diffhunk://#diff-77e918c6d7d639c139f2553ac0770fae447958652ed1ae2b54b8a2ab6bcacc85R1)