### PR TITLE
perf: defer GA to lazyOnload, drop legacy JS polyfills

### DIFF
--- a/apps/portfolio/.browserslistrc
+++ b/apps/portfolio/.browserslistrc
@@ -1,0 +1,4 @@
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Safari versions
+last 2 Edge versions

--- a/apps/portfolio/src/pages/_app.tsx
+++ b/apps/portfolio/src/pages/_app.tsx
@@ -9,9 +9,9 @@ export default function App({ Component, pageProps }: AppProps) {
     <>
       <Script
         src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
-        strategy="afterInteractive"
+        strategy="lazyOnload"
       />
-      <Script id="google-analytics" strategy="afterInteractive">
+      <Script id="google-analytics" strategy="lazyOnload">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
This pull request makes two updates to the portfolio app. First, it adds a `.browserslistrc` file to specify browser compatibility targets. Second, it updates the loading strategy for Google Analytics scripts to improve performance by deferring their loading.

Browser compatibility:

* Added a `.browserslistrc` file specifying support for the last two versions of Chrome, Firefox, Safari, and Edge.

Performance improvements:

* Changed the Google Analytics script loading strategy from `afterInteractive` to `lazyOnload` in `_app.tsx`, which defers loading until after the main page content has loaded.