### PR TITLE
seo: fix robots.txt domain, add multilingual sitemap

### DIFF
--- a/.github/workflows/deploy-portfolio.yml
+++ b/.github/workflows/deploy-portfolio.yml
@@ -6,6 +6,9 @@ on:
       - master
     paths:
       - 'apps/portfolio/**'
+  schedule:
+    # Run every Monday and Thursday at 6 AM UTC
+    - cron: '0 6 * * 1,4'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/apps/portfolio/public/robots.txt
+++ b/apps/portfolio/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://vikum-samare.github.io/sitemap.xml
+Sitemap: https://vikum.dev/sitemap.xml

--- a/apps/portfolio/public/sitemap.xml
+++ b/apps/portfolio/public/sitemap.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+>
+  <url>
+    <loc>https://vikum.dev/</loc>
+    <lastmod>2026-06-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://vikum.dev/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://vikum.dev/de/" />
+    <xhtml:link rel="alternate" hreflang="nl" href="https://vikum.dev/nl/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://vikum.dev/" />
+  </url>
+  <url>
+    <loc>https://vikum.dev/de/</loc>
+    <lastmod>2026-06-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://vikum.dev/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://vikum.dev/de/" />
+    <xhtml:link rel="alternate" hreflang="nl" href="https://vikum.dev/nl/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://vikum.dev/" />
+  </url>
+  <url>
+    <loc>https://vikum.dev/nl/</loc>
+    <lastmod>2026-06-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+    <xhtml:link rel="alternate" hreflang="en" href="https://vikum.dev/" />
+    <xhtml:link rel="alternate" hreflang="de" href="https://vikum.dev/de/" />
+    <xhtml:link rel="alternate" hreflang="nl" href="https://vikum.dev/nl/" />
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://vikum.dev/" />
+  </url>
+</urlset>


### PR DESCRIPTION
This pull request updates the portfolio deployment workflow, improves SEO support, and updates site references to the new domain. The most important changes are grouped below:

**SEO and Site Reference Updates:**

* Added a new `sitemap.xml` at `apps/portfolio/public/sitemap.xml` with alternate language links and updated URLs to use `vikum.dev`, which will help search engines better index the site and support multiple languages.
* Updated the `robots.txt` file to reference the new sitemap location at `https://vikum.dev/sitemap.xml` instead of the old GitHub Pages URL.

**Deployment Workflow Improvements:**

* Modified the GitHub Actions workflow (`.github/workflows/deploy-portfolio.yml`) to schedule automatic deployments every Monday and Thursday at 6 AM UTC, in addition to the existing triggers.