### PR TITLE
chore: update manifest file

### DIFF
--- a/apps/portfolio/public/manifest.json
+++ b/apps/portfolio/public/manifest.json
@@ -8,12 +8,12 @@
   "theme_color": "#22d3ee",
   "icons": [
     {
-      "src": "/icon-192.png",
+      "src": "/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/icon-512.png",
+      "src": "/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }


### PR DESCRIPTION
This pull request updates the icon file references in the `manifest.json` for the portfolio app to use more appropriately named image files.

Manifest icon updates:
* Updated the `src` fields for the app icons in `manifest.json` to use `/android-chrome-192x192.png` and `/android-chrome-512x512.png` instead of the previous `/icon-192.png` and `/icon-512.png` filenames.